### PR TITLE
Typo correction

### DIFF
--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -73,7 +73,7 @@ Metadata:
       AdminServerInstanceType:
         default: Admin server EC2 instance type
       AdminServerRemoteAccessCIDR:
-        default: Allowed CIDR block for external access to the load balancer
+        default: Allowed CIDR block for external access to the admin interface
       AdminServerSubdomain:
         default: 'Subdomain for the admin server'
       AuthToken:


### PR DESCRIPTION
Corrected parameter description for `AdminServerRemoteAccessCIDR`

*Issue #, if available:*

*Description of changes:*
I just noticed this while using the guide. The `AdminServerRemoteAccessCIDR` parameter is described as the CIDR to allow access to the Portal server

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
