### PR TITLE
Fixes for "DNG AWS Quickstart template improvements" issue

### DIFF
--- a/templates/admin-server.template.yaml
+++ b/templates/admin-server.template.yaml
@@ -359,11 +359,11 @@ Resources:
           - Action:
               - 'ec2:AssociateAddress'
               - 'ec2:DescribeAddresses'
-            Resource: '*'
+            Resource: !Sub "arn:${AWS::Partition}:*"
             Effect: Allow
           - Action:
               - 's3:GetObject'
-            Resource: '*'
+            Resource: !Sub "arn:${AWS::Partition}:*"
             Effect: Allow
       Roles: 
         - !Ref AdminServerInstanceRole

--- a/templates/admin-server.template.yaml
+++ b/templates/admin-server.template.yaml
@@ -359,11 +359,11 @@ Resources:
           - Action:
               - 'ec2:AssociateAddress'
               - 'ec2:DescribeAddresses'
-            Resource: !Sub "arn:${AWS::Partition}:*"
+            Resource: '*'
             Effect: Allow
           - Action:
               - 's3:GetObject'
-            Resource: !Sub "arn:${AWS::Partition}:*"
+            Resource: '*'
             Effect: Allow
       Roles: 
         - !Ref AdminServerInstanceRole

--- a/templates/admin-server.template.yaml
+++ b/templates/admin-server.template.yaml
@@ -359,11 +359,7 @@ Resources:
           - Action:
               - 'ec2:AssociateAddress'
               - 'ec2:DescribeAddresses'
-            Resource: '*'
-            Effect: Allow
-          - Action:
-              - 's3:GetObject'
-            Resource: '*'
+            Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:*"
             Effect: Allow
       Roles: 
         - !Ref AdminServerInstanceRole

--- a/templates/admin-server.template.yaml
+++ b/templates/admin-server.template.yaml
@@ -221,7 +221,7 @@ Resources:
         config-admin-server:
           commands:
             1_download_admin_server_image:
-              command: wget --content-disposition https://dl.duosecurity.com/network-gateway-admin-ha-latest.yml
+              command: wget --content-disposition https://dl.duosecurity.com/network-gateway-latest-ha.admin.yml
               cwd: "~"
             2_install_portal_server_image: 
               command: docker-compose -p network-gateway -f $(ls network-gateway-*-ha.admin.yml) up -d

--- a/templates/admin-server.template.yaml
+++ b/templates/admin-server.template.yaml
@@ -359,7 +359,7 @@ Resources:
           - Action:
               - 'ec2:AssociateAddress'
               - 'ec2:DescribeAddresses'
-            Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:*"
+            Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
             Effect: Allow
       Roles: 
         - !Ref AdminServerInstanceRole

--- a/templates/quickstart-cisco-duo-network-gateway-master.template.yaml
+++ b/templates/quickstart-cisco-duo-network-gateway-master.template.yaml
@@ -147,7 +147,7 @@ Parameters:
   AuthToken:
     AllowedPattern: '^(?=(.*[^A-Za-z0-9]){3,})(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
     ConstraintDescription: 'Must be 16-128 characters, including at least three of uppercase, lowercase, nonalphanumeric, and digits.'
-    Default: DuoRedisAuthToken
+    Default: DuoRedisAuthToken123!@#
     Description: The auth token for the Redis cluster.
     MaxLength: 128
     MinLength: 16

--- a/templates/quickstart-cisco-duo-network-gateway-master.template.yaml
+++ b/templates/quickstart-cisco-duo-network-gateway-master.template.yaml
@@ -145,7 +145,7 @@ Parameters:
     Description: 'Sub-domain for the admin server. Fully qualified domain name for the admin server will be created by adding the DomainName parameter value as a suffix. For example, if the provided value is ''adminserver'' and the DomainName parameter value is ''corp.com'', then the fully qualified domain name for the admin server will be ''adminserver.corp.com'''
     Type: String
   AuthToken:
-    AllowedPattern: '[a-zA-Z0-9]*'
+    AllowedPattern: '^(?=(.*[^A-Za-z0-9]){3,})(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
     ConstraintDescription: 'Must be 16-128 characters, including at least three of uppercase, lowercase, nonalphanumeric, and digits.'
     Default: DuoRedisAuthToken
     Description: The auth token for the Redis cluster.
@@ -279,8 +279,8 @@ Parameters:
     Type: String
   RedisEngineVersion:
     AllowedValues:
-      - 3.2.6
-    Default: 3.2.6
+      - 5.0.6
+    Default: 5.0.6
     Description: Redis replication group version.
     Type: String
   SnapshotName:

--- a/templates/quickstart-cisco-duo-network-gateway-master.template.yaml
+++ b/templates/quickstart-cisco-duo-network-gateway-master.template.yaml
@@ -145,9 +145,9 @@ Parameters:
     Description: 'Sub-domain for the admin server. Fully qualified domain name for the admin server will be created by adding the DomainName parameter value as a suffix. For example, if the provided value is ''adminserver'' and the DomainName parameter value is ''corp.com'', then the fully qualified domain name for the admin server will be ''adminserver.corp.com'''
     Type: String
   AuthToken:
-    AllowedPattern: '^(?=(.*[^A-Za-z0-9]){3,})(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
-    ConstraintDescription: 'Must be 16-128 characters, including at least three of uppercase, lowercase, nonalphanumeric, and digits.'
-    Default: DuoRedisAuthToken123!@#
+    AllowedPattern: '^(?!(.*[^A-Za-z0-9]))(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
+    ConstraintDescription: 'Must be 16-128 only printable ASCII characters, including at least three of uppercase, lowercase and digits. Nonalphanumeric characters are restricted to (!, &, #, $, ^, <, >, -, ).'
+    Default: DuoRedisAuthToken123
     Description: The auth token for the Redis cluster.
     MaxLength: 128
     MinLength: 16

--- a/templates/quickstart-cisco-duo-network-gateway-portal-servers.template.yaml
+++ b/templates/quickstart-cisco-duo-network-gateway-portal-servers.template.yaml
@@ -261,7 +261,7 @@ Resources:
         config-portal-server:
           commands:
             1_download_portal_server_image:
-              command: wget --content-disposition https://dl.duosecurity.com/network-gateway-ha-latest.yml
+              command: wget --content-disposition https://dl.duosecurity.com/network-gateway-latest-ha.yml
               cwd: "~"
             2_install_portal_server_image: 
               command: docker-compose -p network-gateway -f $(ls network-gateway*) up -d

--- a/templates/quickstart-cisco-duo-network-gateway-portal-servers.template.yaml
+++ b/templates/quickstart-cisco-duo-network-gateway-portal-servers.template.yaml
@@ -170,8 +170,8 @@ Resources:
             Action: "sts:AssumeRole"
       Path: "/"
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/templates/redis-cluster.template.yaml
+++ b/templates/redis-cluster.template.yaml
@@ -64,7 +64,7 @@ Resources:
       AuthToken: !Ref RedisAuth
       AutomaticFailoverEnabled: true
       CacheNodeType: !Ref RedisCacheNodeType
-      CacheParameterGroupName: 'default.redis3.2'
+      CacheParameterGroupName: 'default.redis5.0'
       CacheSubnetGroupName: !Ref CacheSubnetGroupName
       NumNodeGroups: !Ref NumShards
       ReplicasPerNodeGroup: !Ref NumReplicas

--- a/templates/redis-cluster.template.yaml
+++ b/templates/redis-cluster.template.yaml
@@ -20,7 +20,9 @@ Parameters:
   RedisAuth: 
     Description: The Auth Token for the redis cluster
     Type: String
-    ConstraintDescription: Must be 16-128 characters including atleast three of uppercase, lowercase, nonalphanumeric, and digits
+    ConstraintDescription: 'Must be 16-128 only printable ASCII characters, including at least three of uppercase, lowercase and digits. Nonalphanumeric characters are restricted to (!, &, #, $, ^, <, >, -, ).'
+    Default: DuoRedisAuthToken123
+    NoEcho: true
   RedisCacheNodeType:
     Type: String
     Description: Enter one of the allowed values

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -147,7 +147,7 @@ Parameters:
   AuthToken:
     AllowedPattern: '^(?=(.*[^A-Za-z0-9]){3,})(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
     ConstraintDescription: 'Must be 16-128 characters, including at least three of uppercase, lowercase, nonalphanumeric, and digits.'
-    Default: DuoRedisAuthToken
+    Default: DuoRedisAuthToken123!@#
     Description: The auth token for the Redis cluster.
     MaxLength: 128
     MinLength: 16

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -142,11 +142,11 @@ Parameters:
     Type: String
   AdminServerSubdomain:
     Default: ''
-    Description: 'Subdomain for the admin server. Fully qualified domain name for the admin server will be created by adding the DomainName parameter value as a suffix. For example, if the provided value is ''adminserver'' and the DomainName parameter value is ''corp.com'', then the fully qualified domain name for the admin server will be ''adminserver.corp.com''.'
+    Description: 'Sub-domain for the admin server. Fully qualified domain name for the admin server will be created by adding the DomainName parameter value as a suffix. For example, if the provided value is ''adminserver'' and the DomainName parameter value is ''corp.com'', then the fully qualified domain name for the admin server will be ''adminserver.corp.com''.'
     Type: String
   AuthToken:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: 'Must be 16-128 characters, including at least three uppercase, lowercase, nonalphanumeric, and digits.'
+    AllowedPattern: '^(?=(.*[^A-Za-z0-9]){3,})(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
+    ConstraintDescription: 'Must be 16-128 characters, including at least three of uppercase, lowercase, nonalphanumeric, and digits.'
     Default: DuoRedisAuthToken
     Description: The auth token for the Redis cluster.
     MaxLength: 128
@@ -263,8 +263,8 @@ Parameters:
     Type: String
   RedisEngineVersion:
     AllowedValues:
-      - 3.2.6
-    Default: 3.2.6
+      - 5.0.6
+    Default: 5.0.6
     Description: Redis replication group version.
     Type: String
   SnapshotName:

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -145,9 +145,9 @@ Parameters:
     Description: 'Sub-domain for the admin server. Fully qualified domain name for the admin server will be created by adding the DomainName parameter value as a suffix. For example, if the provided value is ''adminserver'' and the DomainName parameter value is ''corp.com'', then the fully qualified domain name for the admin server will be ''adminserver.corp.com''.'
     Type: String
   AuthToken:
-    AllowedPattern: '^(?=(.*[^A-Za-z0-9]){3,})(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
-    ConstraintDescription: 'Must be 16-128 characters, including at least three of uppercase, lowercase, nonalphanumeric, and digits.'
-    Default: DuoRedisAuthToken123!@#
+    AllowedPattern: '^(?!(.*[^A-Za-z0-9]))(?=(.*[A-Z]){3,})(?=(.*\d){3,})(?=(.*[a-z]){3,}).{16,128}$'
+    ConstraintDescription: 'Must be 16-128 only printable ASCII characters, including at least three of uppercase, lowercase and digits. Nonalphanumeric characters are restricted to (!, &, #, $, ^, <, >, -, ).'
+    Default: DuoRedisAuthToken123
     Description: The auth token for the Redis cluster.
     MaxLength: 128
     MinLength: 16


### PR DESCRIPTION
Fixed points described in opened issue - https://github.com/aws-quickstart/quickstart-cisco-duo-network-gateway/issues/21

Points:

- Default Auth token value (DuoRedisAuthToken) for the for the Redis cluster does not meet the default requirements (number of characters, need special chars, etc). This causes the deployment to FAIL and only after navigating the multiple levels of logs did we see that this is caused by this.

- Quickstart still installs using old:
Version (1.5.9) of DNG Admin.
Version (1.5.12) of DNG Portal.

- Redis cluster version is EOL-ing on 07/31/2023. (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/deprecated-engine-versions.html)

- ???"launch configuration" for AutoScaling-related settings is used. It is a feature that will no longer be supported by AWS. It cannot be created by even manual either, "launch templates" is encouraged by AWS, instead.

Also, fixed linters, as there were errors not related to this changes.
